### PR TITLE
Fix three code bugs

### DIFF
--- a/src-tauri/src/searcher.rs
+++ b/src-tauri/src/searcher.rs
@@ -118,7 +118,8 @@ impl SearchProvider for ClmclmProvider {
     }
 
     async fn search(&self, query: &str, page: u32) -> Result<Vec<SearchResult>> {
-        let url = format!("{}/search-{}-1-1-{}.html", self.base_url, query, page);
+        let encoded_query = urlencoding::encode(query);
+        let url = format!("{}/search-{}-1-1-{}.html", self.base_url, encoded_query, page);
         search_log!(info, "Searching: {}", url);
 
         let response = self.client

--- a/src/components/EnginesPage.vue
+++ b/src/components/EnginesPage.vue
@@ -496,7 +496,7 @@ function generateUrlTemplate(url1: string, url2: string): string {
     fallbackTemplate = fallbackTemplate.replace(/(\W|^)1(\W|$)/g, '$1{page}$2');
 
     // Replace page numbers in query parameters
-    fallbackTemplate = fallbackTemplate.replace(/[&?]page=1/, '&page={page}');
+    fallbackTemplate = fallbackTemplate.replace(/([?&])page=1/, '$1page={page}');
 
     console.log("🔄 Fallback template:", fallbackTemplate);
     return fallbackTemplate;

--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -57,7 +57,7 @@
         </div>
       </div>
       <div class="results-grid">
-        <div v-for="(result, index) in results" :key="index" class="result-item-wrapper">
+        <div v-for="result in results" :key="result.magnet_link || result.source_url || result.title" class="result-item-wrapper">
           <ResultCard
             :title="result.title"
             :original-title="result.originalTitle"

--- a/src/components/ResultCard.vue
+++ b/src/components/ResultCard.vue
@@ -143,8 +143,8 @@ async function quickDownload(magnetLink: string | undefined) {
     <div v-if="fileList && fileList.length > 0" class="file-list-section">
       <div class="file-grid">
         <div
-          v-for="(file, index) in fileList.slice(0, 7)"
-          :key="index"
+          v-for="file in fileList.slice(0, 7)"
+          :key="file"
           class="file-item"
           :title="file"
         >


### PR DESCRIPTION
Fixes three bugs: URL encoding in the backend, unstable Vue list keys, and incorrect URL template query parameter replacement.

*   **Unencoded search query:** The Rust backend now URL-encodes search queries to prevent malformed URLs and potential injection.
*   **Unstable Vue list keys:** Vue `v-for` loops now use stable, unique keys (e.g., `magnet_link`, `file` string) instead of array indices to ensure correct and stable UI rendering.
*   **Query-string fallback mangling:** The URL template generator now correctly preserves the original separator (`?` or `&`) when replacing page numbers in query strings, preventing invalid URLs.